### PR TITLE
Simplify DetailedStatusCode

### DIFF
--- a/saml-utils/src/main/java/uk/gov/ida/saml/core/domain/DetailedStatusCode.java
+++ b/saml-utils/src/main/java/uk/gov/ida/saml/core/domain/DetailedStatusCode.java
@@ -18,7 +18,7 @@ public enum DetailedStatusCode {
     RequesterErrorRequestDeniedFromIdp(StatusCode.REQUESTER,StatusCode.REQUEST_DENIED),
     RequesterErrorFromIdpAsSentByHub(StatusCode.RESPONDER, StatusCode.REQUESTER),
     Healthy(StatusCode.SUCCESS, SamlStatusCode.HEALTHY),
-    UnknownUserCreateFailure(StatusCode.RESPONDER, SamlStatusCode.CREATE_FAILURE),
+    UnknownUserCreateFailure(StatusCode.RESPONDER),
     UnknownUserNoAttributeFailure(StatusCode.RESPONDER),
     UnknownUserCreateSuccess(StatusCode.SUCCESS, SamlStatusCode.CREATED);
 


### PR DESCRIPTION
We don't need to pass in CREATE_FAILURE, that's handled further up the
stack.

(Note: this commit is part of a user research lab session